### PR TITLE
feat: 添加麻将计分奖金番数说明功能

### DIFF
--- a/app/src/main/java/com/example/xiaomaotai/MahjongScore.kt
+++ b/app/src/main/java/com/example/xiaomaotai/MahjongScore.kt
@@ -1,0 +1,282 @@
+package com.example.xiaomaotai
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
+
+/**
+ * 辅助数据类用于解构赋值
+ */
+data class Tuple4<T1, T2, T3, T4>(
+    val first: T1,
+    val second: T2,
+    val third: T3,
+    val fourth: T4
+)
+
+operator fun <T1, T2, T3, T4> Tuple4<T1, T2, T3, T4>.component1(): T1 = first
+operator fun <T1, T2, T3, T4> Tuple4<T1, T2, T3, T4>.component2(): T2 = second
+operator fun <T1, T2, T3, T4> Tuple4<T1, T2, T3, T4>.component3(): T3 = third
+operator fun <T1, T2, T3, T4> Tuple4<T1, T2, T3, T4>.component4(): T4 = fourth
+
+/**
+ * 麻将计分记录数据模型
+ */
+@Serializable
+data class MahjongScore(
+    val id: Int = 0,
+    @SerialName("record_time")
+    val recordTime: String = "", // 格式：2024年12月31日20时30分
+    @SerialName("winner_position")
+    val winnerPosition: String = "", // 胡牌方位：上、下、左、右
+    @SerialName("winner_fan")
+    val winnerFan: Double = 0.0, // 胡牌番数
+    @SerialName("position_data")
+    val positionData: String = "", // JSON格式：各方位红中数、奖金番数
+    @SerialName("calculation_detail")
+    val calculationDetail: String = "", // JSON格式：详细计算过程
+    @SerialName("final_amounts")
+    val finalAmounts: String = "", // JSON格式：各方位最终净金额
+    @SerialName("user_id")
+    val userId: String? = null // 用户ID，未登录时为null
+)
+
+/**
+ * 方位数据
+ */
+@Serializable
+data class PositionData(
+    val fan: Int = 0, // 番数
+    val hongzhong: Int = 0, // 红中数
+    val bonusFan: Double = 0.0 // 奖金番数
+)
+
+/**
+ * 计算详情
+ */
+@Serializable
+data class CalculationDetail(
+    val firstLayer: List<FirstLayerCalculation> = emptyList(), // 第一层胡牌计算
+    val secondLayer: List<SecondLayerCalculation> = emptyList() // 第二层奖金番互算
+)
+
+/**
+ * 第一层胡牌计算
+ */
+@Serializable
+data class FirstLayerCalculation(
+    val fromPosition: String, // 支付方位
+    val toPosition: String, // 收取方位
+    val winnerFanAmount: Double, // 胡牌方每番金额
+    val payerMultiplier: Int, // 支付方红中倍数
+    val finalAmount: Double, // 最终转账金额
+    val formula: String // 计算公式
+)
+
+/**
+ * 第二层奖金番互算
+ */
+@Serializable
+data class SecondLayerCalculation(
+    val fromPosition: String, // 支付方位
+    val toPosition: String, // 收取方位
+    val higherFanAmount: Double, // 高方每番金额
+    val payerMultiplier: Int, // 支付方红中倍数
+    val finalAmount: Double, // 最终转账金额
+    val formula: String // 计算公式
+)
+
+/**
+ * 最终金额
+ */
+@Serializable
+data class FinalAmounts(
+    val up: Double = 0.0, // 上方位净金额
+    val down: Double = 0.0, // 下方位净金额（雀神）
+    val left: Double = 0.0, // 左方位净金额
+    val right: Double = 0.0 // 右方位净金额
+)
+
+/**
+ * 麻将计分计算器
+ */
+object MahjongCalculator {
+    
+    /**
+     * 计算麻将得分
+     * @param winnerPosition 胡牌方位
+     * @param winnerFan 胡牌番数
+     * @param positionData 各方位数据
+     * @return 计算结果
+     */
+    fun calculateScore(
+        winnerPosition: String,
+        winnerFan: Double,
+        positionData: Map<String, PositionData>
+    ): Pair<CalculationDetail, FinalAmounts> {
+        
+        val positions = listOf("up", "down", "left", "right")
+        val firstLayerCalculations = mutableListOf<FirstLayerCalculation>()
+        val secondLayerCalculations = mutableListOf<SecondLayerCalculation>()
+        
+        // 临时金额记录
+        val tempAmounts = mutableMapOf<String, Double>().apply {
+            positions.forEach { put(it, 0.0) }
+        }
+        
+        // 第一层：胡牌计算
+        val winnerData = positionData[winnerPosition] ?: PositionData()
+        val winnerMultiplier = winnerData.hongzhong + 1
+        
+        positions.filter { it != winnerPosition }.forEach { position ->
+            val posData = positionData[position] ?: PositionData()
+            val payerMultiplier = posData.hongzhong + 1
+            
+            // 修正算法：(胡牌番数-奖金番) × (胡牌者红中+1) × 10 × (支付者红中+1)
+            val effectiveFan = winnerFan - posData.bonusFan
+            val finalAmount = effectiveFan * winnerMultiplier * 10 * payerMultiplier
+            
+            val formula = "(${winnerFan}-${posData.bonusFan})×${winnerMultiplier}×10×${payerMultiplier} = ${finalAmount}元"
+            
+            firstLayerCalculations.add(
+                FirstLayerCalculation(
+                    fromPosition = position,
+                    toPosition = winnerPosition,
+                    winnerFanAmount = effectiveFan,
+                    payerMultiplier = payerMultiplier,
+                    finalAmount = finalAmount,
+                    formula = formula
+                )
+            )
+            
+            // 更新临时金额
+            tempAmounts[position] = tempAmounts[position]!! - finalAmount
+            tempAmounts[winnerPosition] = tempAmounts[winnerPosition]!! + finalAmount
+        }
+        
+        // 第二层：奖金番互算
+        val nonWinnerPositions = positions.filter { it != winnerPosition }
+        for (i in nonWinnerPositions.indices) {
+            for (j in i + 1 until nonWinnerPositions.size) {
+                val pos1 = nonWinnerPositions[i]
+                val pos2 = nonWinnerPositions[j]
+                val data1 = positionData[pos1] ?: PositionData()
+                val data2 = positionData[pos2] ?: PositionData()
+                
+                // 跳过奖金番相等的情况（包括都为0的情况）
+                if (data1.bonusFan == data2.bonusFan) {
+                    continue
+                }
+                
+                val (higherPos, lowerPos, higherData, lowerData) = if (data1.bonusFan > data2.bonusFan) {
+                    Tuple4(pos1, pos2, data1, data2)
+                } else {
+                    Tuple4(pos2, pos1, data2, data1)
+                }
+                
+                val higherMultiplier = higherData.hongzhong + 1
+                val lowerMultiplier = lowerData.hongzhong + 1
+                
+                // 修正算法：(高奖金番-低奖金番) × (高奖金番方红中+1) × 10 × (低奖金番方红中+1)
+                val fanDifference = higherData.bonusFan - lowerData.bonusFan
+                val finalAmount = fanDifference * higherMultiplier * 10 * lowerMultiplier
+                
+                val formula = "(${higherData.bonusFan}-${lowerData.bonusFan})×${higherMultiplier}×10×${lowerMultiplier} = ${finalAmount}元"
+                
+                secondLayerCalculations.add(
+                    SecondLayerCalculation(
+                        fromPosition = lowerPos,
+                        toPosition = higherPos,
+                        higherFanAmount = fanDifference,
+                        payerMultiplier = lowerMultiplier,
+                        finalAmount = finalAmount,
+                        formula = formula
+                    )
+                )
+                
+                // 更新临时金额
+                tempAmounts[lowerPos] = tempAmounts[lowerPos]!! - finalAmount
+                tempAmounts[higherPos] = tempAmounts[higherPos]!! + finalAmount
+            }
+        }
+        
+        val calculationDetail = CalculationDetail(firstLayerCalculations, secondLayerCalculations)
+        val finalAmounts = FinalAmounts(
+            up = tempAmounts["up"] ?: 0.0,
+            down = tempAmounts["down"] ?: 0.0,
+            left = tempAmounts["left"] ?: 0.0,
+            right = tempAmounts["right"] ?: 0.0
+        )
+        
+        return Pair(calculationDetail, finalAmounts)
+    }
+    
+    /**
+     * 验证输入数据
+     */
+    fun validateInput(
+        winnerPosition: String?,
+        winnerFan: Double?,
+        positionData: Map<String, PositionData>
+    ): String? {
+        // 检查是否有胡牌方
+        if (winnerPosition.isNullOrBlank()) {
+            return "请选择胡牌方位"
+        }
+        
+        // 检查胡牌方番数
+        if (winnerFan == null) {
+            return "请输入胡牌番数"
+        }
+        
+        // 检查番数格式（必须是0.5的倍数）
+        if (winnerFan < 0 || (winnerFan * 2) % 1 != 0.0) {
+            return "胡牌番数必须是0.5的倍数"
+        }
+        
+        // 检查各方位数据
+        positionData.forEach { (position, data) ->
+            // 检查红中数（必须是非负整数）
+            if (data.hongzhong < 0) {
+                return "${getPositionName(position)}的红中数必须是非负整数"
+            }
+            
+            // 检查奖金番数格式（必须是0.5的倍数）
+            if (data.bonusFan < 0 || (data.bonusFan * 2) % 1 != 0.0) {
+                return "${getPositionName(position)}的奖金番数必须是0.5的倍数"
+            }
+            
+            // 胡牌方不能有奖金番数
+            if (position == winnerPosition && data.bonusFan > 0) {
+                return "胡牌方不能输入奖金番数"
+            }
+        }
+        
+        return null // 验证通过
+    }
+    
+    /**
+     * 获取方位中文名称
+     */
+    fun getPositionName(position: String): String {
+        return when (position) {
+            "up" -> "上家"
+            "down" -> "雀神"
+            "left" -> "下家"
+            "right" -> "对家"
+            else -> position
+        }
+    }
+    
+    /**
+     * 获取方位显示名称
+     */
+    fun getPositionDisplayName(position: String): String {
+        return when (position) {
+            "up" -> "上家"
+            "down" -> "雀神"
+            "left" -> "下家"
+            "right" -> "对家"
+            else -> position
+        }
+    }
+}

--- a/app/src/main/java/com/example/xiaomaotai/ui/components/MahjongDialogs.kt
+++ b/app/src/main/java/com/example/xiaomaotai/ui/components/MahjongDialogs.kt
@@ -1,0 +1,522 @@
+package com.example.xiaomaotai.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import com.example.xiaomaotai.*
+
+/**
+ * 规则说明对话框
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RulesDialog(
+    onDismiss: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.8f),
+            elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize()
+            ) {
+                // 标题栏
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "麻将计分规则",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.Default.Close, contentDescription = "关闭")
+                    }
+                }
+                
+                // 规则内容
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    RuleSection(
+                        title = "基础设定",
+                        content = """
+                            • 基础金额：1番 = 10元，0.5番 = 5元
+                            • 游戏人数：4人
+                            • 红中机制：红中数量+1 = 实际倍数
+                              (0个红中=1倍，1个红中=2倍，依此类推)
+                        """.trimIndent()
+                    )
+                    
+                    RuleSection(
+                        title = "方位说明",
+                        content = """
+                            • 四个方位：雀神（自己）、上家、下家、对家
+                            • 四个方位中仅有一位可以胡牌
+                            • 所有输赢金额总和为0（平衡）
+                        """.trimIndent()
+                    )
+                    
+                    RuleSection(
+                        title = "输入规则",
+                        content = """
+                            • 番数：仅胡牌方可输入，必须是0.5的倍数
+                            • 红中数：只能输入非负整数
+                            • 奖金番数：非胡牌方输入，必须是0.5的倍数
+                            • 胡牌方不能输入奖金番数
+                        """.trimIndent()
+                    )
+                    
+                    RuleSection(
+                        title = "计算逻辑",
+                        content = """
+                            第一层：胡牌计算
+                            • 计算公式：(胡牌番数 - 奖金番) × (胡牌者红中+1) × 10 × (支付者红中+1)
+                            • 每个非胡牌方都要向胡牌方支付相应金额
+                            • 注意：如果胡牌番数小于奖金番，结果为负数，表示胡牌方要向该方支付
+                            
+                            第二层：奖金番互算
+                            • 步骤1：计算奖金番差值 = 高奖金番 - 低奖金番
+                            • 步骤2：奖金番高的人每番价值 = 奖金番差值 × (高奖金番方红中+1) × 10元
+                            • 步骤3：奖金番低的人支付 = 每番价值 × (低奖金番方红中+1)
+                            • 计算公式：(高奖金番-低奖金番) × (高奖金番方红中+1) × 10 × (低奖金番方红中+1)
+                            • 注意：如果两家奖金番相等（包括都为0），则跳过该对的计算
+                        """.trimIndent()
+                    )
+                    
+                    RuleSection(
+                        title = "计算示例（四家游戏）",
+                        content = """
+                            假设：雀神胡牌2番，红中1个
+                            上家：红中0个，奖金番1
+                            下家：红中2个，奖金番0.5
+                            对家：红中1个，奖金番0
+                            
+                            第一层胡牌计算：
+                            • 上家支付：(2-1)×(1+1)×10×(0+1)=20元
+                            • 下家支付：(2-0.5)×(1+1)×10×(2+1)=90元
+                            • 对家支付：(2-0)×(1+1)×10×(1+1)=80元
+                            
+                            第二层奖金番互算：
+                            • 下家向上家支付：(1-0.5)×(0+1)×10×(2+1)=15元
+                            • 对家向上家支付：(1-0)×(0+1)×10×(1+1)=20元
+                            • 对家向下家支付：(0.5-0)×(2+1)×10×(1+1)=30元
+                            
+                            最终结果（总和=0）：
+                            • 雀神：+190元（20+90+80）
+                            • 上家：+15元（-20+15+20）
+                            • 下家：-75元（-90-15+30）
+                            • 对家：-130元（-80-20-30）
+                        """.trimIndent()
+                    )
+                    
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
+            }
+        }
+    }
+}
+
+/**
+ * 计算结果对话框
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ResultDialog(
+    calculationDetail: CalculationDetail,
+    finalAmounts: FinalAmounts,
+    onDismiss: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.8f),
+            elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize()
+            ) {
+                // 标题栏
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "计算结果",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.Default.Close, contentDescription = "关闭")
+                    }
+                }
+                
+                // 结果内容
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    // 最终金额汇总
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer
+                        )
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(16.dp)
+                        ) {
+                            Text(
+                                text = "最终结果",
+                                fontSize = 16.sp,
+                                fontWeight = FontWeight.Bold,
+                                modifier = Modifier.padding(bottom = 8.dp)
+                            )
+                            
+                            FinalAmountItem("对家", finalAmounts.up)
+                            FinalAmountItem("上家", finalAmounts.left)
+                            FinalAmountItem("下家", finalAmounts.right)
+                            FinalAmountItem("雀神", finalAmounts.down)
+                        }
+                    }
+                    
+                    Spacer(modifier = Modifier.height(16.dp))
+                    
+                    // 第一层胡牌计算详情
+                    if (calculationDetail.firstLayer.isNotEmpty()) {
+                        Text(
+                            text = "第一层：胡牌计算",
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(bottom = 8.dp)
+                        )
+                        
+                        calculationDetail.firstLayer.forEach { calc ->
+                            CalculationItem(
+                                title = "${MahjongCalculator.getPositionDisplayName(calc.fromPosition)} → ${MahjongCalculator.getPositionDisplayName(calc.toPosition)}",
+                                formula = calc.formula,
+                                amount = calc.finalAmount
+                            )
+                        }
+                        
+                        Spacer(modifier = Modifier.height(16.dp))
+                    }
+                    
+                    // 第二层奖金番互算详情
+                    if (calculationDetail.secondLayer.isNotEmpty()) {
+                        Text(
+                            text = "第二层：奖金番互算",
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(bottom = 8.dp)
+                        )
+                        
+                        calculationDetail.secondLayer.forEach { calc ->
+                            CalculationItem(
+                                title = "${MahjongCalculator.getPositionDisplayName(calc.fromPosition)} → ${MahjongCalculator.getPositionDisplayName(calc.toPosition)}",
+                                formula = calc.formula,
+                                amount = calc.finalAmount
+                            )
+                        }
+                        
+                        Spacer(modifier = Modifier.height(16.dp))
+                    }
+                    
+                    // 关闭按钮
+                    Button(
+                        onClick = onDismiss,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 16.dp)
+                    ) {
+                        Text("确定")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RuleSection(
+    title: String,
+    content: String
+) {
+    Column(
+        modifier = Modifier.padding(bottom = 16.dp)
+    ) {
+        Text(
+            text = title,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(bottom = 4.dp)
+        )
+        Text(
+            text = content,
+            fontSize = 12.sp,
+            lineHeight = 16.sp
+        )
+    }
+}
+
+@Composable
+private fun FinalAmountItem(
+    positionName: String,
+    amount: Double
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = positionName,
+            fontSize = 14.sp
+        )
+        Text(
+            text = when {
+                amount > 0 -> "+${amount}元"
+                amount < 0 -> "${amount}元"
+                else -> "0元"
+            },
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Bold,
+            color = when {
+                amount > 0 -> Color(0xFF4CAF50)
+                amount < 0 -> Color(0xFFF44336)
+                else -> MaterialTheme.colorScheme.onSurface
+            }
+        )
+    }
+}
+
+@Composable
+private fun CalculationItem(
+    title: String,
+    formula: String,
+    amount: Double
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 8.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp)
+        ) {
+            Text(
+                text = title,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = formula,
+                fontSize = 11.sp,
+                modifier = Modifier.padding(vertical = 4.dp)
+            )
+            Text(
+                text = "转账金额：${amount}元",
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold,
+                color = if (amount > 0) Color(0xFF4CAF50) else Color(0xFFF44336)
+            )
+        }
+    }
+}
+
+/**
+ * 奖金番数说明对话框
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FanInfoDialog(
+    onDismiss: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.8f),
+            elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize()
+            ) {
+                // 标题栏
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "奖金番数说明",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.Default.Close, contentDescription = "关闭")
+                    }
+                }
+                
+                // 内容区域
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    // 番数部分
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.primaryContainer
+                        )
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(16.dp)
+                        ) {
+                            Text(
+                                text = "番数对照表",
+                                fontSize = 16.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                            
+                            val fanData = listOf(
+                                "回头笑" to "0.5番",
+                                "胡牌" to "1番",
+                                "顶杠" to "1番", 
+                                "门清胡牌" to "1.5番",
+                                "暗杠" to "2番",
+                                "对子胡" to "3番",
+                                "软霍带" to "3番",
+                                "硬霍带" to "5番",
+                                "清一色" to "5番",
+                                "七对" to "5番",
+                                "裸奔" to "7番",
+                                "夹七对" to "10番"
+                            )
+                            
+                            fanData.forEach { (name, fan) ->
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 2.dp),
+                                    horizontalArrangement = Arrangement.SpaceBetween
+                                ) {
+                                    Text(
+                                        text = name,
+                                        fontSize = 14.sp,
+                                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                                    )
+                                    Text(
+                                        text = fan,
+                                        fontSize = 14.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    
+                    Spacer(modifier = Modifier.height(16.dp))
+                    
+                    // 牌型介绍部分
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer
+                        )
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(16.dp)
+                        ) {
+                            Text(
+                                text = "牌型详细介绍",
+                                fontSize = 16.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onSecondaryContainer
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                            
+                            val typeDescriptions = listOf(
+                                "回头笑" to "自己碰了牌，然后又摸到一张一样的，放下去",
+                                "胡牌" to "碰牌后再胡",
+                                "顶杠" to "自己打的牌或者别人打的牌被杠下来",
+                                "门清胡牌" to "可以有回头笑和暗杠，只要没碰胡牌",
+                                "暗杠" to "自己摸到四张一样的牌型",
+                                "对子胡" to "碰牌后，最后两个对子胡牌",
+                                "软霍带" to "碰了之后（要自己碰），又摸到这张牌胡了，或者手里有一杠，先碰了手里还留有一张，再摸牌胡了",
+                                "硬霍带" to "胡牌时手里有四张一样的牌（没有暗杠下来）",
+                                "清一色" to "全部是一个花色的牌型胡了（包括碰、杠都要是一个色）",
+                                "七对" to "手里七个对子胡了",
+                                "裸奔" to "手里只剩一张牌胡牌",
+                                "夹七对" to "手里五个对子加四张一样的牌型（没有暗杠下来）"
+                            )
+                            
+                            typeDescriptions.forEach { (name, description) ->
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 4.dp)
+                                ) {
+                                    Text(
+                                        text = "• $name",
+                                        fontSize = 14.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        color = MaterialTheme.colorScheme.onSecondaryContainer
+                                    )
+                                    Text(
+                                        text = description,
+                                        fontSize = 13.sp,
+                                        color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.8f),
+                                        modifier = Modifier.padding(start = 12.dp, top = 2.dp)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/xiaomaotai/ui/components/MahjongScoreScreen.kt
+++ b/app/src/main/java/com/example/xiaomaotai/ui/components/MahjongScoreScreen.kt
@@ -1,0 +1,789 @@
+package com.example.xiaomaotai.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import android.widget.Toast
+import com.example.xiaomaotai.*
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.delay
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MahjongScoreScreen(
+    dataManager: DataManager,
+    onNavigateToHistory: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var winnerPosition by remember { mutableStateOf<String?>(null) }
+    var winnerFan by remember { mutableStateOf("") }
+    var showRulesDialog by remember { mutableStateOf(false) }
+    var showFanInfoDialog by remember { mutableStateOf(false) }
+    var showResultDialog by remember { mutableStateOf(false) }
+    var calculationResult by remember { mutableStateOf<Pair<CalculationDetail, FinalAmounts>?>(null) }
+    var isCalculating by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    var showToast by remember { mutableStateOf(false) }
+    var toastMessage by remember { mutableStateOf("") }
+    var showErrorToast by remember { mutableStateOf(false) }
+    var errorToastMessage by remember { mutableStateOf("") }
+    
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val mahjongDataManager = remember { MahjongDataManager(context) }
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+    
+    // 各方位数据
+    var upData by remember { mutableStateOf(PositionData()) }
+    var downData by remember { mutableStateOf(PositionData()) }
+    var leftData by remember { mutableStateOf(PositionData()) }
+    var rightData by remember { mutableStateOf(PositionData()) }
+    
+    // 输入框状态
+    var upHongzhong by remember { mutableStateOf("") }
+    var upBonusFan by remember { mutableStateOf("") }
+    var upFan by remember { mutableStateOf("") }
+    var downHongzhong by remember { mutableStateOf("") }
+    var downBonusFan by remember { mutableStateOf("") }
+    var downFan by remember { mutableStateOf("") }
+    var leftHongzhong by remember { mutableStateOf("") }
+    var leftBonusFan by remember { mutableStateOf("") }
+    var leftFan by remember { mutableStateOf("") }
+    var rightHongzhong by remember { mutableStateOf("") }
+    var rightBonusFan by remember { mutableStateOf("") }
+    var rightFan by remember { mutableStateOf("") }
+    
+    // 更新数据的函数
+    fun updatePositionData() {
+        upData = PositionData(
+            fan = upFan.toIntOrNull() ?: 0,
+            hongzhong = upHongzhong.toIntOrNull() ?: 0,
+            bonusFan = upBonusFan.toDoubleOrNull() ?: 0.0
+        )
+        downData = PositionData(
+            fan = downFan.toIntOrNull() ?: 0,
+            hongzhong = downHongzhong.toIntOrNull() ?: 0,
+            bonusFan = downBonusFan.toDoubleOrNull() ?: 0.0
+        )
+        leftData = PositionData(
+            fan = leftFan.toIntOrNull() ?: 0,
+            hongzhong = leftHongzhong.toIntOrNull() ?: 0,
+            bonusFan = leftBonusFan.toDoubleOrNull() ?: 0.0
+        )
+        rightData = PositionData(
+            fan = rightFan.toIntOrNull() ?: 0,
+            hongzhong = rightHongzhong.toIntOrNull() ?: 0,
+            bonusFan = rightBonusFan.toDoubleOrNull() ?: 0.0
+        )
+    }
+    
+    // 清空所有数据
+    fun clearAllData() {
+        winnerPosition = null
+        winnerFan = ""
+        upHongzhong = ""
+        upBonusFan = ""
+        upFan = ""
+        downHongzhong = ""
+        downBonusFan = ""
+        downFan = ""
+        leftHongzhong = ""
+        leftBonusFan = ""
+        leftFan = ""
+        rightHongzhong = ""
+        rightBonusFan = ""
+        rightFan = ""
+        // 清除焦点和关闭键盘
+        focusManager.clearFocus()
+        keyboardController?.hide()
+        errorMessage = null
+        calculationResult = null
+    }
+    
+    // 设置胡牌方位
+    fun setWinnerPosition(position: String) {
+        if (winnerPosition == position) {
+            // 取消胡牌状态
+            winnerPosition = null
+            winnerFan = ""
+        } else {
+            // 设置新的胡牌方位
+            winnerPosition = position
+            // 清空原胡牌方的番数
+            winnerFan = ""
+            // 清空其他方的番数输入
+            if (position != "up") upFan = ""
+            if (position != "down") downFan = ""
+            if (position != "left") leftFan = ""
+            if (position != "right") rightFan = ""
+            // 清空新胡牌方的奖金番数
+            when (position) {
+                "up" -> upBonusFan = ""
+                "down" -> downBonusFan = ""
+                "left" -> leftBonusFan = ""
+                "right" -> rightBonusFan = ""
+            }
+        }
+    }
+    
+    // 验证输入
+    fun validateInput(): String? {
+        if (winnerPosition == null) {
+            return "请选择胡牌方位"
+        }
+        
+        val winnerFanValue = winnerFan.toDoubleOrNull()
+        if (winnerFanValue == null) {
+            return "请输入有效的胡牌番数"
+        }
+        
+        updatePositionData()
+        val positionData = mapOf(
+            "up" to upData, "down" to downData, "left" to leftData, "right" to rightData
+        )
+        
+        return MahjongCalculator.validateInput(winnerPosition, winnerFanValue, positionData)
+    }
+    
+    // 计算并保存
+    fun calculateAndSave() {
+        val validationError = validateInput()
+        if (validationError != null) {
+            // 显示错误Toast
+            errorToastMessage = validationError
+            showErrorToast = true
+            scope.launch {
+                delay(2000)
+                showErrorToast = false
+            }
+            return
+        }
+        
+        isCalculating = true
+        errorMessage = null
+        
+        scope.launch {
+            try {
+                updatePositionData()
+                
+                val positionDataMap = mapOf(
+                    "up" to upData,
+                    "down" to downData,
+                    "left" to leftData,
+                    "right" to rightData
+                )
+                
+                val result = MahjongCalculator.calculateScore(
+                    winnerPosition = winnerPosition!!,
+                    winnerFan = winnerFan.toDouble(),
+                    positionData = positionDataMap
+                )
+                
+                // 不在页面上显示结果，只在弹窗中显示
+                // calculationResult = result
+                
+                // 检查用户登录状态
+                val currentUserId = if (dataManager.isLoggedIn()) dataManager.getCurrentUserId() else null
+                android.util.Log.d("MahjongScore", "用户登录状态: ${dataManager.isLoggedIn()}, 用户ID: $currentUserId")
+                
+                // 保存到数据库（自动包含云端同步）
+                val saveResult = mahjongDataManager.saveMahjongScore(
+                    winnerPosition = winnerPosition!!,
+                    winnerFan = winnerFan.toDouble(),
+                    positionData = positionDataMap,
+                    calculationDetail = result.first.toString(),
+                    finalAmounts = result.second,
+                    userId = currentUserId
+                )
+                
+                // 检查保存结果
+                if (saveResult <= 0) {
+                    throw Exception("数据保存失败")
+                }
+                
+                android.util.Log.d("MahjongScore", "数据保存成功，ID: $saveResult")
+                
+                // 直接显示计算结果弹窗，不显示成功Toast
+                calculationResult = result
+                showResultDialog = true
+                
+            } catch (e: Exception) {
+                // 显示错误Toast
+                errorToastMessage = "计算失败: ${e.message}"
+                showErrorToast = true
+                scope.launch {
+                    delay(2000)
+                    showErrorToast = false
+                }
+            } finally {
+                isCalculating = false
+            }
+        }
+    }
+    
+    Column(
+    modifier = Modifier
+        .fillMaxSize()
+        .imePadding() // 添加键盘避让
+        .padding(12.dp)
+        .clickable(
+            indication = null,
+            interactionSource = remember { MutableInteractionSource() }
+        ) {
+            // 点击空白区域清空焦点并关闭键盘
+            focusManager.clearFocus()
+            keyboardController?.hide()
+        },
+    verticalArrangement = Arrangement.spacedBy(8.dp)
+) {
+    // 顶部标题栏：感叹号在左侧，标题居中，历史入口在右上角
+    Box(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center
+    ) {
+        // 左侧感叹号图标
+        IconButton(
+            onClick = { showFanInfoDialog = true },
+            modifier = Modifier.align(Alignment.CenterStart)
+        ) {
+            Icon(
+                Icons.Default.Info,
+                contentDescription = "奖金番数说明",
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+        
+        Text(
+            text = "麻将计分",
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold
+        )
+        
+        TextButton(
+            onClick = onNavigateToHistory,
+            modifier = Modifier.align(Alignment.CenterEnd)
+        ) {
+            Text("历史记录")
+        }
+    }
+    
+    Spacer(modifier = Modifier.height(32.dp))
+    
+    // 四方位布局 - 顶部对家；中间：上家|按钮|下家；底部：雀神
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        // 顶部：对家（标题下面）
+        HorizontalPositionCard(
+            position = "right",
+            displayName = "对家",
+            isWinner = winnerPosition == "right",
+            hongzhongValue = rightHongzhong,
+            bonusFanValue = rightBonusFan,
+            fanValue = if (winnerPosition == "right") winnerFan else "",
+            onHongzhongChange = { rightHongzhong = it },
+            onBonusFanChange = { if (winnerPosition != "right") rightBonusFan = it },
+            onFanChange = { if (winnerPosition == "right") winnerFan = it },
+            onWinnerClick = { setWinnerPosition("right") },
+            finalAmount = calculationResult?.second?.right
+        )
+
+        // 中间行：左=上家 | 中=开始按钮 | 右=下家
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp)
+        ) {
+            // 上家（左侧）
+            PositionCard(
+                position = "up",
+                displayName = "上家",
+                isWinner = winnerPosition == "up",
+                hongzhongValue = upHongzhong,
+                bonusFanValue = upBonusFan,
+                fanValue = if (winnerPosition == "up") winnerFan else "",
+                onHongzhongChange = { upHongzhong = it },
+                onBonusFanChange = { if (winnerPosition != "up") upBonusFan = it },
+                onFanChange = { if (winnerPosition == "up") winnerFan = it },
+                onWinnerClick = { setWinnerPosition("up") },
+                finalAmount = calculationResult?.second?.up,
+                modifier = Modifier
+                    .width(105.dp)
+                    .align(Alignment.CenterStart)
+                    .offset(x = (-12).dp)
+            )
+
+            // 开始按钮（中间）- 保持居中不变
+            Button(
+                onClick = { calculateAndSave() },
+                modifier = Modifier
+                    .size(85.dp)
+                    .align(Alignment.Center),
+                shape = CircleShape,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                )
+            ) {
+                Text(
+                    "开始\n计算",
+                    textAlign = TextAlign.Center,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White
+                )
+            }
+
+            // 下家（右侧）
+            PositionCard(
+                position = "left",
+                displayName = "下家",
+                isWinner = winnerPosition == "left",
+                hongzhongValue = leftHongzhong,
+                bonusFanValue = leftBonusFan,
+                fanValue = if (winnerPosition == "left") winnerFan else "",
+                onHongzhongChange = { leftHongzhong = it },
+                onBonusFanChange = { if (winnerPosition != "left") leftBonusFan = it },
+                onFanChange = { if (winnerPosition == "left") winnerFan = it },
+                onWinnerClick = { setWinnerPosition("left") },
+                finalAmount = calculationResult?.second?.left,
+                modifier = Modifier
+                    .width(105.dp)
+                    .align(Alignment.CenterEnd)
+                    .offset(x = 12.dp)
+            )
+        }
+
+        // 底部：雀神
+        HorizontalPositionCard(
+            position = "down",
+            displayName = "雀神",
+            isWinner = winnerPosition == "down",
+            hongzhongValue = downHongzhong,
+            bonusFanValue = downBonusFan,
+            fanValue = if (winnerPosition == "down") winnerFan else "",
+            onHongzhongChange = { downHongzhong = it },
+            onBonusFanChange = { if (winnerPosition != "down") downBonusFan = it },
+            onFanChange = { if (winnerPosition == "down") winnerFan = it },
+            onWinnerClick = { setWinnerPosition("down") },
+            finalAmount = calculationResult?.second?.down
+        )
+    }
+    
+        
+        Spacer(modifier = Modifier.height(12.dp))
+        
+        // 底部按钮
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 32.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // 使用规则按钮
+            OutlinedButton(
+                onClick = { showRulesDialog = true },
+                modifier = Modifier
+                    .weight(1f)
+                    .height(56.dp),
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp)
+            ) {
+                Text(
+                    text = "使用规则", 
+                    fontSize = 13.sp,
+                    maxLines = 1,
+                    textAlign = TextAlign.Center
+                )
+            }
+            
+            // 重置按钮
+            OutlinedButton(
+                onClick = { 
+                    // 恢复到完全初始状态
+                    clearAllData()
+                    calculationResult = null
+                    showResultDialog = false
+                    errorMessage = null
+                    showToast = false
+                    showErrorToast = false
+                },
+                modifier = Modifier
+                    .weight(1f)
+                    .height(56.dp),
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 12.dp)
+            ) {
+                Text(
+                    text = "重置", 
+                    fontSize = 13.sp,
+                    maxLines = 1,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+        
+
+    }
+    
+    // 成功Toast显示
+    if (showToast) {
+        Dialog(
+            onDismissRequest = { 
+                showToast = false
+            },
+            properties = DialogProperties(
+                dismissOnBackPress = true,
+                dismissOnClickOutside = true
+            )
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clickable(indication = null, interactionSource = remember { MutableInteractionSource() }) {
+                        showToast = false
+                    },
+                contentAlignment = Alignment.Center
+            ) {
+                Card(
+                    modifier = Modifier.padding(32.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer
+                    ),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+                ) {
+                    Text(
+                        text = toastMessage,
+                        modifier = Modifier.padding(24.dp),
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+            }
+        }
+    }
+    
+    // 错误Toast显示
+    if (showErrorToast) {
+        Dialog(
+            onDismissRequest = { 
+                showErrorToast = false
+            },
+            properties = DialogProperties(
+                dismissOnBackPress = true,
+                dismissOnClickOutside = true
+            )
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clickable(indication = null, interactionSource = remember { MutableInteractionSource() }) {
+                        showErrorToast = false
+                    },
+                contentAlignment = Alignment.Center
+            ) {
+                Card(
+                    modifier = Modifier.padding(32.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer
+                    ),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+                ) {
+                    Text(
+                        text = errorToastMessage,
+                        modifier = Modifier.padding(24.dp),
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                }
+            }
+        }
+    }
+    
+    // 规则说明对话框
+    if (showRulesDialog) {
+        RulesDialog(
+            onDismiss = { showRulesDialog = false }
+        )
+    }
+    
+    // 奖金番数说明对话框
+    if (showFanInfoDialog) {
+        FanInfoDialog(
+            onDismiss = { showFanInfoDialog = false }
+        )
+    }
+    
+    // 计算结果对话框
+    if (showResultDialog && calculationResult != null) {
+        ResultDialog(
+            calculationDetail = calculationResult!!.first,
+            finalAmounts = calculationResult!!.second,
+            onDismiss = { 
+                showResultDialog = false
+                // 关闭结果弹窗后恢复默认状态并清空所有输入
+                calculationResult = null
+                errorMessage = null
+                showToast = false
+                showErrorToast = false
+                // 清空所有输入和选择状态
+                clearAllData()
+            }
+        )
+    }
+}
+
+
+
+@Composable
+fun HorizontalPositionCard(
+    position: String,
+    displayName: String,
+    isWinner: Boolean,
+    hongzhongValue: String,
+    bonusFanValue: String,
+    fanValue: String,
+    onHongzhongChange: (String) -> Unit,
+    onBonusFanChange: (String) -> Unit,
+    onFanChange: (String) -> Unit,
+    onWinnerClick: () -> Unit,
+    finalAmount: Double?,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isWinner) MaterialTheme.colorScheme.primaryContainer 
+                           else MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(12.dp)
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // 左侧：方位名称和胡牌按钮
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Text(
+                    text = displayName,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center
+                )
+                
+                Button(
+                    onClick = onWinnerClick,
+                    modifier = Modifier
+                        .width(80.dp)
+                        .height(32.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = if (isWinner) MaterialTheme.colorScheme.primary 
+                                       else MaterialTheme.colorScheme.outline
+                    )
+                ) {
+                    Text(
+                        text = if (isWinner) "胡牌" else "胡牌",
+                        fontSize = 10.sp
+                    )
+                }
+            }
+            
+            // 中间：输入框区域
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // 第一个输入框：奖金番（非胡牌方）或番数（胡牌方）
+                OutlinedTextField(
+                    value = if (isWinner) fanValue else bonusFanValue,
+                    onValueChange = if (isWinner) onFanChange else onBonusFanChange,
+                    label = { Text(if (isWinner) "番数" else "奖金番", fontSize = 10.sp) },
+                    modifier = Modifier.width(80.dp),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    textStyle = androidx.compose.ui.text.TextStyle(fontSize = 12.sp),
+                    singleLine = true
+                )
+                
+                // 第二个输入框：红中数输入（位置保持不变）
+                OutlinedTextField(
+                    value = hongzhongValue,
+                    onValueChange = onHongzhongChange,
+                    label = { Text("红中", fontSize = 10.sp) },
+                    modifier = Modifier.width(80.dp),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    textStyle = androidx.compose.ui.text.TextStyle(fontSize = 12.sp),
+                    singleLine = true
+                )
+            }
+            
+            // 右侧：最终金额显示
+            finalAmount?.let { amount ->
+                Text(
+                    text = if (amount > 0) "+${amount}元" 
+                          else if (amount < 0) "${amount}元" 
+                          else "0元",
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = when {
+                        amount > 0 -> Color(0xFF4CAF50) // 绿色表示赢
+                        amount < 0 -> Color(0xFFF44336) // 红色表示输
+                        else -> MaterialTheme.colorScheme.onSurface
+                    },
+                    modifier = Modifier
+                        .background(
+                            color = MaterialTheme.colorScheme.surfaceVariant,
+                            shape = RoundedCornerShape(4.dp)
+                        )
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun PositionCard(
+    position: String,
+    displayName: String,
+    isWinner: Boolean,
+    hongzhongValue: String,
+    bonusFanValue: String,
+    fanValue: String,
+    onHongzhongChange: (String) -> Unit,
+    onBonusFanChange: (String) -> Unit,
+    onFanChange: (String) -> Unit,
+    onWinnerClick: () -> Unit,
+    finalAmount: Double?,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .width(120.dp)
+            .padding(4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isWinner) MaterialTheme.colorScheme.primaryContainer 
+                           else MaterialTheme.colorScheme.surface
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(8.dp)
+                .heightIn(min = 200.dp), // 增加最小高度确保金额显示区域
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(6.dp) // 增加间距
+        ) {
+            // 胡牌按钮
+            Button(
+                onClick = onWinnerClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(32.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = if (isWinner) MaterialTheme.colorScheme.primary 
+                                   else MaterialTheme.colorScheme.outline
+                )
+            ) {
+                Text(
+                    text = if (isWinner) "胡牌" else "胡牌",
+                    fontSize = 10.sp
+                )
+            }
+            
+            // 方位名称
+            Text(
+                text = displayName,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center
+            )
+            
+            // 第一个输入框：奖金番（非胡牌方）或番数（胡牌方）
+            OutlinedTextField(
+                value = if (isWinner) fanValue else bonusFanValue,
+                onValueChange = if (isWinner) onFanChange else onBonusFanChange,
+                label = { Text(if (isWinner) "番数" else "奖金番", fontSize = 11.sp) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                textStyle = androidx.compose.ui.text.TextStyle(fontSize = 14.sp),
+                singleLine = true
+            )
+            
+            // 第二个输入框：红中数输入（位置保持不变）
+            OutlinedTextField(
+                value = hongzhongValue,
+                onValueChange = onHongzhongChange,
+                label = { Text("红中", fontSize = 11.sp) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                textStyle = androidx.compose.ui.text.TextStyle(fontSize = 14.sp),
+                singleLine = true
+            )
+            
+            // 最终金额显示
+            finalAmount?.let { amount ->
+                Text(
+                    text = if (amount > 0) "+${amount}元" 
+                          else if (amount < 0) "${amount}元" 
+                          else "0元",
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = when {
+                        amount > 0 -> Color(0xFF4CAF50) // 绿色表示赢
+                        amount < 0 -> Color(0xFFF44336) // 红色表示输
+                        else -> MaterialTheme.colorScheme.onSurface
+                    },
+                    modifier = Modifier
+                        .background(
+                            color = MaterialTheme.colorScheme.surfaceVariant,
+                            shape = RoundedCornerShape(4.dp)
+                        )
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
- 在麻将计分标题左侧添加感叹号图标入口
- 新增FanInfoDialog组件显示奖金番数对照表和牌型介绍
- 包含12种牌型的番数和详细规则说明
- 按番数从小到大排序，界面美观易读
- 与使用规则弹窗保持一致的交互体验