### PR TITLE
fix: keep-alive 改用 API 保活，绕开 main 分支保护

### DIFF
--- a/.github/workflows/keep_alive.yml
+++ b/.github/workflows/keep_alive.yml
@@ -8,8 +8,11 @@ on:
     - cron: '0 12 * * *'  # 每天 UTC 时间 12:00（北京时间 20:00）执行
   workflow_dispatch:  # 允许手动触发
 
+# main 受分支保护，机器人无法直接推送提交；
+# 保活改用 GitHub API 重置 60 天定时器，无需 contents 写权限
 permissions:
-  contents: write
+  contents: read
+  actions: write
 
 jobs:
   keep-alive:
@@ -18,9 +21,6 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        fetch-depth: 0
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
@@ -49,57 +49,14 @@ jobs:
         echo "开始执行脚本..."
         python scripts/keep_alive.py
 
-    - name: Write heartbeat and commit
+    # GitHub 会在仓库 60 天无活动后停用 schedule 触发的 workflow。
+    # 旧方案往 main 提交心跳文件，被分支保护拒绝（GH006）。
+    # 改为调用官方 API 重新启用本 workflow，效果等同于重置计时器，
+    # 不产生任何提交（社区标准做法，参见 gautamkrishnar/keepalive-workflow 的 API 模式）。
+    - name: Keep workflow alive via API
       if: always()
       env:
-        RUN_STATUS: ${{ steps.keep_alive.outcome }}
-        RUN_ID: ${{ github.run_id }}
-        RUN_NUMBER: ${{ github.run_number }}
-        WORKFLOW: ${{ github.workflow }}
-        ACTOR: ${{ github.actor }}
-        EVENT_NAME: ${{ github.event_name }}
-        TARGET_BRANCH: ${{ github.ref_name }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        set -euo pipefail
-        mkdir -p .github
-        HEARTBEAT_FILE=".github/keep_alive_heartbeat.json"
-
-        export TIMESTAMP_UTC
-        export TIMESTAMP_CST
-        TIMESTAMP_UTC=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-        TIMESTAMP_CST=$(TZ=Asia/Shanghai date +"%Y-%m-%d %H:%M:%S %Z")
-
-        python <<'PY'
-        import json
-        import os
-        import time
-        from pathlib import Path
-
-        path = Path(".github/keep_alive_heartbeat.json")
-        data = {
-            "last_run_utc": os.environ.get("TIMESTAMP_UTC", ""),
-            "last_run_cst": os.environ.get("TIMESTAMP_CST", ""),
-            "status": os.environ.get("RUN_STATUS", "unknown"),
-            "run_id": os.environ.get("RUN_ID", "0"),
-            "run_number": int(os.environ.get("RUN_NUMBER") or "0"),
-            "workflow": os.environ.get("WORKFLOW", ""),
-            "event_name": os.environ.get("EVENT_NAME", ""),
-            "actor": os.environ.get("ACTOR", ""),
-            "touch_unix": int(time.time()),
-            "purpose": "Keep GitHub Actions active by committing a heartbeat after each keep-alive run",
-        }
-        path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        print(path.read_text(encoding="utf-8"))
-        PY
-
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-        git add "$HEARTBEAT_FILE"
-        if git diff --cached --quiet; then
-          echo "No heartbeat changes detected"
-          exit 0
-        fi
-
-        git commit -m "chore(keep-alive): heartbeat ${TIMESTAMP_UTC} (${RUN_STATUS:-unknown})"
-        git push origin "HEAD:${TARGET_BRANCH}"
+        gh api -X PUT "repos/${{ github.repository }}/actions/workflows/keep_alive.yml/enable"
+        echo "已通过 API 重置 workflow 停用计时器"


### PR DESCRIPTION
main 开启了分支保护（Changes must be made through a pull request）， keep-alive 往 main 直推心跳提交被拒（GH006）导致 workflow 失败。

心跳提交的唯一目的是防止仓库 60 天无活动后 schedule workflow 被
GitHub 自动停用。改为调用官方 API 重新启用 workflow 达到同样效果：
- 不再产生任何提交，与分支保护规则无冲突
- 权限从 contents:write 收窄为 actions:write
- 附带效果：auto-tag workflow 不会再被心跳提交触发